### PR TITLE
[ASSIGNMENT] 2차 과제 구현

### DIFF
--- a/src/main/java/org/sopt/common/ApiResponse.java
+++ b/src/main/java/org/sopt/common/ApiResponse.java
@@ -2,18 +2,31 @@ package org.sopt.common;
 
 public record ApiResponse<T>(
         boolean success,
+        String code,
         String message,
         T data
 ) {
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, "요청이 성공했습니다.", data);
+    // 200 OK, 데이터 있음
+    public static <T> ApiResponse<T> ok(String message, T data) {
+        return new ApiResponse<>(true, CommonSuccessCode.OK.getCode(), message, data);
     }
 
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(true, message, data);
+    // 200 OK, 데이터 없음
+    public static <T> ApiResponse<T> ok(String message) {
+        return new ApiResponse<>(true, CommonSuccessCode.OK.getCode(), message, null);
     }
 
-    public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(false, message, null);
+    // 201 Created, 데이터 있음
+    public static <T> ApiResponse<T> created(String message, T data) {
+        return new ApiResponse<>(true, CommonSuccessCode.CREATED.getCode(), message, data);
+    }
+
+    // 201 Created, 데이터 없음
+    public static <T> ApiResponse<T> created(String message) {
+        return new ApiResponse<>(true, CommonSuccessCode.CREATED.getCode(), message, null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
     }
 }

--- a/src/main/java/org/sopt/common/CommonErrorCode.java
+++ b/src/main/java/org/sopt/common/CommonErrorCode.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum CommonErrorCode implements ErrorCode {
 
-    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/common/CommonErrorCode.java
+++ b/src/main/java/org/sopt/common/CommonErrorCode.java
@@ -1,0 +1,28 @@
+package org.sopt.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    CommonErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() { return httpStatus; }
+
+    @Override
+    public String getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/src/main/java/org/sopt/common/CommonSuccessCode.java
+++ b/src/main/java/org/sopt/common/CommonSuccessCode.java
@@ -1,0 +1,28 @@
+package org.sopt.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonSuccessCode implements SuccessCode {
+
+    OK(HttpStatus.OK, "COMMON_200", "요청이 성공했습니다."),
+    CREATED(HttpStatus.CREATED, "COMMON_201", "생성이 완료되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    CommonSuccessCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() { return httpStatus; }
+
+    @Override
+    public String getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/src/main/java/org/sopt/common/CustomException.java
+++ b/src/main/java/org/sopt/common/CustomException.java
@@ -1,0 +1,13 @@
+package org.sopt.common;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() { return errorCode; }
+}

--- a/src/main/java/org/sopt/common/ErrorCode.java
+++ b/src/main/java/org/sopt/common/ErrorCode.java
@@ -1,0 +1,9 @@
+package org.sopt.common;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/org/sopt/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/common/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package org.sopt.common;
 
-import org.sopt.exception.PostNotFoundException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -9,24 +7,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(PostNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handlePostNotFound(PostNotFoundException e) {
+    // CustomException을 상속한 모든 예외 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.error(e.getMessage()));
+                .status(e.getErrorCode().getHttpStatus())
+                .body(ApiResponse.error(e.getErrorCode()));
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(e.getMessage()));
-    }
-
+    // 그 외 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 내부 오류가 발생했습니다."));
+                .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/org/sopt/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.sopt.common;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,6 +14,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(ApiResponse.error(e.getErrorCode()));
+    }
+
+    // JSON 파싱 실패
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        return ResponseEntity
+                .status(CommonErrorCode.BAD_REQUEST.getHttpStatus())
+                .body(ApiResponse.error(CommonErrorCode.BAD_REQUEST));
     }
 
     // 그 외 예외 처리

--- a/src/main/java/org/sopt/common/SuccessCode.java
+++ b/src/main/java/org/sopt/common/SuccessCode.java
@@ -1,0 +1,9 @@
+package org.sopt.common;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -1,9 +1,9 @@
 package org.sopt.controller;
 
+import org.sopt.common.ApiResponse;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
-import org.sopt.dto.response.CreatePostResponse;
-import org.sopt.dto.response.PostResponse;
+import org.sopt.dto.response.*;
 import org.sopt.service.PostService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,45 +23,51 @@ public class PostController {
 
     // POST /posts
     @PostMapping
-    public ResponseEntity<CreatePostResponse> createPost(
+    public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
             @RequestBody CreatePostRequest request
     ) {
         CreatePostResponse response = postService.createPost(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success("게시글 등록 완료!", response));
     }
 
     // GET /posts
     @GetMapping
-    public ResponseEntity<List<PostResponse>> getAllPosts() {
-        //TODO
-        return null;
+    public ResponseEntity<ApiResponse<List<PostListResponse>>> getAllPosts() {
+        List<PostListResponse> posts = postService.getAllPosts();
+        return ResponseEntity
+                .ok(ApiResponse.success("게시글 목록 조회 완료!", posts));
     }
 
     // GET /posts/{id}
     @GetMapping("/{id}")
-    public ResponseEntity<PostResponse> getPost(
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(
             @PathVariable Long id
     ) {
-        //TODO
-        return null;
+        PostResponse post = postService.getPost(id);
+        return ResponseEntity
+                .ok(ApiResponse.success("게시글 단건 조회 완료!", post));
     }
 
     // PUT /posts/{id}
     @PutMapping("/{id}")
-    public ResponseEntity<Void> updatePost(
+    public ResponseEntity<ApiResponse<UpdatePostResponse>> updatePost(
             @PathVariable Long id,
             @RequestBody UpdatePostRequest request
     ) {
-        //TODO
-        return null;
+        UpdatePostResponse response = postService.updatePost(id, request);
+        return ResponseEntity
+                .ok(ApiResponse.success("게시글 수정 완료!", response));
     }
 
     // DELETE /posts/{id}
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<ApiResponse<DeletePostResponse>> deletePost(
             @PathVariable Long id
     ) {
-        //TODO
-        return null;
+        DeletePostResponse response = postService.deletePost(id);
+        return ResponseEntity
+                .ok(ApiResponse.success("게시글 삭제 완료!", response));
     }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -29,7 +29,7 @@ public class PostController {
         CreatePostResponse response = postService.createPost(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(ApiResponse.success("게시글 등록 완료!", response));
+                .body(ApiResponse.created("게시글 등록 완료!", response));
     }
 
     // GET /posts
@@ -37,7 +37,7 @@ public class PostController {
     public ResponseEntity<ApiResponse<List<PostListResponse>>> getAllPosts() {
         List<PostListResponse> posts = postService.getAllPosts();
         return ResponseEntity
-                .ok(ApiResponse.success("게시글 목록 조회 완료!", posts));
+                .ok(ApiResponse.ok("게시글 목록 조회 완료!", posts));
     }
 
     // GET /posts/{id}
@@ -47,7 +47,7 @@ public class PostController {
     ) {
         PostResponse post = postService.getPost(id);
         return ResponseEntity
-                .ok(ApiResponse.success("게시글 단건 조회 완료!", post));
+                .ok(ApiResponse.ok("게시글 단건 조회 완료!", post));
     }
 
     // PUT /posts/{id}
@@ -58,7 +58,7 @@ public class PostController {
     ) {
         UpdatePostResponse response = postService.updatePost(id, request);
         return ResponseEntity
-                .ok(ApiResponse.success("게시글 수정 완료!", response));
+                .ok(ApiResponse.ok("게시글 수정 완료!", response));
     }
 
     // DELETE /posts/{id}
@@ -68,6 +68,6 @@ public class PostController {
     ) {
         DeletePostResponse response = postService.deletePost(id);
         return ResponseEntity
-                .ok(ApiResponse.success("게시글 삭제 완료!", response));
+                .ok(ApiResponse.ok("게시글 삭제 완료!", response));
     }
 }

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -6,5 +6,4 @@ public record CreatePostRequest(
         String content,
         String author
 ) {
-
 }

--- a/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
@@ -5,5 +5,4 @@ public record UpdatePostRequest(
         String title,
         String content
 ) {
-
 }

--- a/src/main/java/org/sopt/dto/response/CreatePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/CreatePostResponse.java
@@ -1,9 +1,22 @@
 package org.sopt.dto.response;
 
+import org.sopt.domain.Post;
+
 // 게시글 작성 응답
 public record CreatePostResponse(
         Long id,
-        String message
+        String title,
+        String content,
+        String author,
+        String createdAt
 ) {
-
+    public static CreatePostResponse from(Post post) {
+        return new CreatePostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getAuthor(),
+                post.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/org/sopt/dto/response/DeletePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/DeletePostResponse.java
@@ -1,5 +1,6 @@
 package org.sopt.dto.response;
 
+// 게시글 수정 응답
 public record DeletePostResponse(
         Long id
 ) {

--- a/src/main/java/org/sopt/dto/response/DeletePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/DeletePostResponse.java
@@ -1,6 +1,6 @@
 package org.sopt.dto.response;
 
-// 게시글 수정 응답
+// 게시글 삭제 응답
 public record DeletePostResponse(
         Long id
 ) {

--- a/src/main/java/org/sopt/dto/response/DeletePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/DeletePostResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.dto.response;
+
+public record DeletePostResponse(
+        Long id
+) {
+}

--- a/src/main/java/org/sopt/dto/response/PostListResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostListResponse.java
@@ -2,19 +2,17 @@ package org.sopt.dto.response;
 
 import org.sopt.domain.Post;
 
-// 게시글 단건 조회 응답
-public record PostResponse(
+// 게시글 리스트 조회 응답
+public record PostListResponse(
         Long id,
         String title,
-        String content,
         String author,
         String createdAt
 ) {
-    public static PostResponse from(Post post) {
-        return new PostResponse(
+    public static PostListResponse from(Post post) {
+        return new PostListResponse(
                 post.getId(),
                 post.getTitle(),
-                post.getContent(),
                 post.getAuthor(),
                 post.getCreatedAt()
         );

--- a/src/main/java/org/sopt/dto/response/PostListResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostListResponse.java
@@ -6,6 +6,7 @@ import org.sopt.domain.Post;
 public record PostListResponse(
         Long id,
         String title,
+        String content,
         String author,
         String createdAt
 ) {
@@ -13,6 +14,7 @@ public record PostListResponse(
         return new PostListResponse(
                 post.getId(),
                 post.getTitle(),
+                post.getContent(),
                 post.getAuthor(),
                 post.getCreatedAt()
         );

--- a/src/main/java/org/sopt/dto/response/UpdatePostResponse.java
+++ b/src/main/java/org/sopt/dto/response/UpdatePostResponse.java
@@ -2,16 +2,16 @@ package org.sopt.dto.response;
 
 import org.sopt.domain.Post;
 
-// 게시글 단건 조회 응답
-public record PostResponse(
+// 게시글 수정 응답
+public record UpdatePostResponse(
         Long id,
         String title,
         String content,
         String author,
         String createdAt
 ) {
-    public static PostResponse from(Post post) {
-        return new PostResponse(
+    public static UpdatePostResponse from(Post post) {
+        return new UpdatePostResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),

--- a/src/main/java/org/sopt/exception/PostErrorCode.java
+++ b/src/main/java/org/sopt/exception/PostErrorCode.java
@@ -1,0 +1,31 @@
+package org.sopt.exception;
+
+import org.sopt.common.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum PostErrorCode implements ErrorCode {
+
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_001", "해당 게시글이 존재하지 않습니다."),
+    POST_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "POST_002", "제목은 필수입니다."),
+    POST_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "POST_003", "제목은 50자 이하여야 합니다."),
+    POST_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "POST_004", "내용은 필수입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    PostErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() { return httpStatus; }
+
+    @Override
+    public String getCode() { return code; }
+
+    @Override
+    public String getMessage() { return message; }
+}

--- a/src/main/java/org/sopt/exception/PostException.java
+++ b/src/main/java/org/sopt/exception/PostException.java
@@ -1,0 +1,10 @@
+package org.sopt.exception;
+
+import org.sopt.common.CustomException;
+
+public class PostException extends CustomException {
+
+    public PostException(PostErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/sopt/exception/PostNotFoundException.java
+++ b/src/main/java/org/sopt/exception/PostNotFoundException.java
@@ -1,7 +1,0 @@
-package org.sopt.exception;
-
-public class PostNotFoundException extends RuntimeException {
-    public PostNotFoundException(Long id) {
-        super("해당 게시글이 존재하지 않습니다. id = " + id);
-    }
-}

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -3,8 +3,7 @@ package org.sopt.service;
 import org.sopt.domain.Post;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
-import org.sopt.dto.response.CreatePostResponse;
-import org.sopt.dto.response.PostResponse;
+import org.sopt.dto.response.*;
 import org.sopt.exception.PostNotFoundException;
 import org.sopt.repository.PostRepository;
 import org.sopt.validator.PostValidator;
@@ -31,14 +30,14 @@ public class PostService {
         String createdAt = java.time.LocalDateTime.now().toString();
         Post post = new Post(postRepository.generateId(), request.title(), request.content(), request.author(), createdAt);
         postRepository.save(post);
-        return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
+        return CreatePostResponse.from(post);
     }
 
     // READ - 전체
-    public List<PostResponse> getAllPosts() {
+    public List<PostListResponse> getAllPosts() {
         return postRepository.findAll()
                 .stream()
-                .map(PostResponse::from)
+                .map(PostListResponse::from)
                 .toList();
     }
 
@@ -51,21 +50,22 @@ public class PostService {
     }
 
     // UPDATE
-    public void updatePost(Long id, UpdatePostRequest request) {
+    public UpdatePostResponse updatePost(Long id, UpdatePostRequest request) {
         // ID로 게시글 조회, 존재하지 않으면 예외 발생
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new PostNotFoundException(id));
         // 새로운 제목, 내용 유효성 검증 후 업데이트
         postValidator.validate(request.title(), request.content());
         post.update(request.title(), request.content());
+        return UpdatePostResponse.from(post);
     }
 
     // DELETE
-    public void deletePost(Long id) {
-        // 삭제 실패 시 (존재하지 않는 ID) 예외 발생
+    public DeletePostResponse deletePost(Long id) {
         boolean isDeleted = postRepository.deleteById(id);
         if (!isDeleted) {
             throw new PostNotFoundException(id);
         }
+        return new DeletePostResponse(id);
     }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -4,7 +4,8 @@ import org.sopt.domain.Post;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.*;
-import org.sopt.exception.PostNotFoundException;
+import org.sopt.exception.PostErrorCode;
+import org.sopt.exception.PostException;
 import org.sopt.repository.PostRepository;
 import org.sopt.validator.PostValidator;
 import org.springframework.stereotype.Service;
@@ -46,14 +47,14 @@ public class PostService {
         // ID로 게시글 조회, 존재하지 않으면 예외 발생
         return postRepository.findById(id)
                 .map(PostResponse::from)
-                .orElseThrow(() -> new PostNotFoundException(id));
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
     }
 
     // UPDATE
     public UpdatePostResponse updatePost(Long id, UpdatePostRequest request) {
         // ID로 게시글 조회, 존재하지 않으면 예외 발생
         Post post = postRepository.findById(id)
-                .orElseThrow(() -> new PostNotFoundException(id));
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
         // 새로운 제목, 내용 유효성 검증 후 업데이트
         postValidator.validate(request.title(), request.content());
         post.update(request.title(), request.content());
@@ -64,7 +65,7 @@ public class PostService {
     public DeletePostResponse deletePost(Long id) {
         boolean isDeleted = postRepository.deleteById(id);
         if (!isDeleted) {
-            throw new PostNotFoundException(id);
+            throw new PostException(PostErrorCode.POST_NOT_FOUND);
         }
         return new DeletePostResponse(id);
     }

--- a/src/main/java/org/sopt/validator/PostValidator.java
+++ b/src/main/java/org/sopt/validator/PostValidator.java
@@ -1,5 +1,7 @@
 package org.sopt.validator;
 
+import org.sopt.exception.PostErrorCode;
+import org.sopt.exception.PostException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -10,17 +12,17 @@ public class PostValidator {
     // 제목 검증
     public void validateTitle(String title) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("제목은 필수입니다!");
+            throw new PostException(PostErrorCode.POST_TITLE_REQUIRED);
         }
         if (title.length() > MAX_TITLE_LENGTH) {
-            throw new IllegalArgumentException("제목은 50자 이하여야 합니다!");
+            throw new PostException(PostErrorCode.POST_TITLE_TOO_LONG);
         }
     }
 
     // 내용 검증
     public void validateContent(String content) {
         if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("내용은 필수입니다!");
+            throw new PostException(PostErrorCode.POST_CONTENT_REQUIRED);
         }
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*


## 👷 **과제 구현**

### 필수과제
- [x] 세미나에서 TODO로 남겨둔 Read(전체) / Read(단건) / Update / Delete Controller, Service를 완성해주세요
- [x] 에브리타임 화면설계서를 와인잔조 조원들과 함께 보고, 게시글 목록 / 상세 / 작성 / 수정 / 삭제 API에 대한 API 명세서를 노션으로 작성해주세요. Method, URL, Request Body, Response Body, 상태 코드를 포함해주세요. 노션 링크를 PR에 첨부해주세요
- [x] PostNotFoundException 커스텀 예외 클래스를 만들고, @RestControllerAdvice로 적절한 HTTP 상태 코드와 함께 응답하도록 구현해주세요. 에러 코드 체계도 함께 고민해봐요 (예: POST_001: 게시글을 찾을 수 없습니다)
- [x] ApiResponse<T> 공통 응답 객체를 설계하고, 모든 API의 성공/실패 응답이 일관된 형식을 갖도록 적용해주세요
- [x] 완성한 API 전체를 Postman으로 테스트하고, 각 API의 성공/실패 응답 화면을 캡처해서 PR에 첨부해주세요

<br>

### 선택과제
- [x] 에러 코드를 enum으로 관리해보세요. ErrorCode enum에 상태 코드와 메시지를 함께 정의하고, GlobalExceptionHandler가 이를 활용하도록 구성해주세요

<br>

### **구현한 내용에 대해서 설명해주세요**
1. **CRUD Controller / Service 완성**
2. **에브리타임 API 명세서** [API 명세서](https://obvious-tango-d68.notion.site/34b9a45ba18980268730ef3c07d98033?v=34b9a45ba189808bbbed000c9e747fec&source=copy_link)

3. **예외 처리 체계**

    - `ErrorCode` 인터페이스를 기반으로 에러 코드를 enum으로 관리했습니다. 에러 코드에는 HTTP 상태 코드, 코드 문자열, 메시지를 정의했습니다.
        - `CommonErrorCode` : 특정 도메인에 속하지 않는 공통 에러
        - `PostErrorCode` : 게시글 도메인 관련 에러
    - `CustomException`이 `ErrorCode`를 받아 예외를 생성하도록 했습니다.
    - `PostException`이 `PostErrorCode`만 받도록 강제하여 컴파일 타임에 잘못된 에러 코드 사용을 방지했습니다.
    - `GlobalExceptionHandler`를 만들고 `@RestControllerAdvice`로 예외를 한 곳에서 처리했습니다. 특정 도메인 예외를 핸들러에 직접 명시하는 대신, `CustomException` 하나로 모든 커스텀 예외를 처리하도록 설계했습니다. 

    ```
        PostException
                ↓
        CustomException으로 올라감
                ↓
        GlobalExceptionHandler의 handleCustomException()이 처리
                ↓
        ErrorCode에 정의된 상태 코드와 메시지로 ApiResponse.error() 반환
    ```

4. **`ApiResponse<T>` 공통 응답 객체 설계**
    - 기존 ApiResponse에 code 필드를 추가했습니다.
    - 성공 응답의 경우 `ok()`, `created()` 메서드로 나눠서 상태코드별로 응답하게 했습니다.

5. **API 포스트맨 테스트**
	<details>
	<summary>게시글 생성</summary>
	
	- 게시글 생성 (201 Created)  
	![게시글 생성](https://github.com/user-attachments/assets/c352919e-072d-4d34-8ddf-25374a0c36b9)
	
	- 게시글 생성 - 제목 50자 초과 (400 Bad Request)  
	![제목 초과](https://github.com/user-attachments/assets/325511ab-d6f7-47da-aad1-2bd04d5c6a6c)
	
	- 게시글 생성 - 제목 필드 X (400 Bad Request)  
	![제목 없음](https://github.com/user-attachments/assets/a1cfe996-54b9-4ded-ba86-90b1acf8e872)
	
	- 게시글 생성 - 내용 필드 X (400 Bad Request)  
	![내용 없음](https://github.com/user-attachments/assets/1ce5f0a2-9b5c-4b92-983a-0329a3c1cf43)
	
	</details>

	<details>
	<summary>게시글 목록 조회</summary>
	
	- 게시글 목록 조회 (200 OK)  
	![게시글 목록 조회](https://github.com/user-attachments/assets/d0289b53-d034-4a24-9721-ac7262130d19)
	
	</details>

	<details>
	<summary>게시글 단건 조회</summary>
	
	- 게시글 단건 조회 (200 OK)  
	![게시글 단건 조회](https://github.com/user-attachments/assets/54a57ee4-2008-4a7d-9c22-9a034688c1b8)
	
	- 게시글 단건 조회 - 존재하지 않는 게시글 ID (404 Not Found)  
	![없는 ID](https://github.com/user-attachments/assets/595a7361-d307-4a53-a975-012854082b12)
	
	</details>

	<details>
	<summary>게시글 수정</summary>
	
	- 게시글 수정 (200 OK)  
	![수정](https://github.com/user-attachments/assets/a8612ad6-9861-4250-bb83-4e10fbf34dd8)
	
	</details>

	<details>
	<summary>게시글 삭제</summary>
	
	- 게시글 삭제 (200 OK)  
	![삭제](https://github.com/user-attachments/assets/a6f6da4e-b97c-4a8d-92cd-7a6afb3b57c6)
	
	</details>

	<details>
	<summary>서버 오류</summary>
	
	- 서버 오류 (500 Internal Server Error)  
	![서버 오류](https://github.com/user-attachments/assets/ae4a7e54-db41-4c55-8abb-fcf2336c2634)
	
	</details>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**
API별 성공 응답도 에러 코드처럼 enum으로 관리해야 할지 고민했습니다.

에러의 경우에는 어떤 도메인에서 어떤 문제가 발생했는지를 클라이언트에 명확하게 전달해야 하기 때문에, 구체적인 코드 관리가 필요하다고 생각했습니다. 반면 성공 응답은 “요청이 정상적으로 처리되었다”는 의미 전달이 중심이고, 상황별로 세분화해 재사용할 필요성은 상대적으로 크지 않다고 판단했습니다.

그래서 모든 API에 대해 성공 케이스를 enum으로 세분화하기보다는,  `CommonSuccessCode`에 `OK`, `CREATED` 정도만 정의하고,  `ApiResponse`에서 `ok()`, `created()` 메서드로 구분하도록 구현했습니다.  응답 메시지는 컨트롤러에서 직접 전달하도록 했습니다.

다른 분들은 어떻게 생각하시는지 궁금합니다..!

<br>

---
### **키워드 과제 정리내용**

<details>
<summary>HTTP의 멱등성(Idempotency)이란 무엇인가요? GET, POST, PUT, DELETE 중 멱등한 메서드는 무엇인가요?</summary>

<br>

**멱등성** - 첫 번째 수행을 한 뒤 여러 차례 적용해도 결과를 변경시키지 않는 작업 또는 기능의 속성
- 멱등한 API는 두 번 이상 요청해도 처음 요청과 똑같은 결과가 돌아옴
- 서버 상태(DB)에도 영향을 미치지 않음

**멱등한 메서드**
- GET : 멱등함. 데이터를 한 번 조회하든 여러 번을 조회하든 같은 결과가 조회됨.
- POST : 멱등하지 않음. 요청을 여러번 보내는 경우 서버에 매번 새로운 자원이 생겨남 -> 서버의 상태가 변경됨.
- PUT : 멱등함. 같은 자원에 같은 내용으로 여러 번 덮어쓰면 결과가 같음.
- DELETE : 멱등함. 첫 삭제 후에는 대상이 사라져 있고, 이후 같은 삭제 요청을 반복해도 상태는 같음.

</details>

<details>
<summary>`@Controller`와 `@RestController`의 차이는 무엇인가요?</summary>

<br>

- `@Controller` : 주로 뷰를 반환하는 컨트롤러. 메서드가 문자열 뷰 이름을 반환하면 Spring이 ViewResolver를 통해 JSP, Thymeleaf같은 화면을 찾아서 렌더링함. 서버 사이드 렌더링에 많이 사용됨.
- `@RestController` : `@Controller + @ResponseBody`. 메서드 반환값을 뷰 이름으로 해석하지 않고, http 응답 본문에 그대로 실어서 JSON 같은 데이터로 돌려줌.

</details>

<details>
<summary>Java Record란 무엇인가요? 기존 클래스와 비교해서 어떤 점이 다른가요?</summary>

<br>

- 데이터를 담는 불변 객체를 간결하게 생성하기 위한 클래스 타입.
- Java 14에서 도입, Java 16부터 정식 기능.
- 필드 선언, 생성자, getter 역할, equals, hashCode, toString 같은 반복 코드를 Java가 자동으로 만들어줌.
- 필드는 기본적으로 final이기 때문에 불변.
- 다른 클래스나 레코드를 상속할 수 없음. 상속되어 확장될 수 없음.
- DTO처럼 값을 담는 객체를 만들 때 유용

</details>

<details>
<summary>Optional이란 무엇이고, 왜 null 대신 쓰는 건가요?</summary>

<br>

- 값이 있을 수도 있고, 없을 수도 있음을 타입으로 표현하는 도구.
- null을 직접 다루는 대신 값이 비어 있을 가능성을 명시적으로 다루도록 도와줌.
- NullPointerException을 줄이고, null 체크를 코드 곳곳에 쓰지 않게 만들어줌.
- orElse, orElseThrow, map, filter 같은 메서드 체이닝으로 안전하게 처리할 수 있음.

	
</details>

<details>
<summary>Spring Bean의 생명주기란 무엇인가요?</summary>

<br>

Spring Bean 생명주기 : 스프링 컨테이너가 빈을 생성하고, 의존성을 주입하고, 초기화한 뒤, 사용하다가, 컨테이너 종료 시 소멸시키는 전체 과정.

1. 스프링 컨테이너 생성
2. 빈 객체 생성
3. 의존관계 주입
4. 초기화 콜백 실행
5. 빈 사용
6. 소멸 전 콜백 실행
7. 컨테이너 종료


</details>

<details>
<summary>Spring Boot의 구동 원리를 DispatcherServlet 동작 방식 위주로 정리해주세요</summary>

<br>

Spring Boot로 웹 애플리케이션을 실행하면, 내부적으로 Spring MVC의 Front Controller인 DispatcherServlet이 핵심 진입점 역할을 한다. 클라이언트 요청이 들어오면 먼저 DispatcherServlet이 받고, 그 뒤에 적절한 컨트롤러와 핸들러를 찾아 요청을 처리한다.

1. 브라우저나 클라이언트가 http 요청 전송
2. 서블릿 컨테이너가 DispatcherServlet에 요청 전달
3. HandlerMapping이 요청 URL에 맞는 컨트롤러를 찾음
4. HandlerAdapter가 해당 메서드를 호출할 수 있게 연결
5. 컨트롤러가 서비스 계층을 호출해 비즈니스 로직 수행
6. 결과를 ModelAndView 또는 응답 데이터로 반환
7. ViewResolver가 뷰를 찾거나, @ResponseBody/@RestController면 메시지 변환기가 JSON 등으로 응답 생성

Spring Boot는 이런 구성 요소들을 자동 설정해줘서 개발자가 신경쓰지 않게 해준다.

	
</details>

<br>

---

## 🚨 참고 사항
시험 끝나면 심화 과제도 꼭 해보겠습니다...